### PR TITLE
Add folder support

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
   "devDependencies": {
     "@types/node": "^12.0.10",
     "tsc-watch": "^2.2.1",
-    "typescript": "^3.5.2"
+    "typescript": "^3.7.5"
   }
 }

--- a/src/zsc.ts
+++ b/src/zsc.ts
@@ -1,11 +1,21 @@
 import { Color, exec, Format, Shell } from '.';
 import { VERSION } from './core/constants';
 
+/**
+ * The workspace type of the current directory's Z-Script.
+ * * File: a single file called "zscript.ts";
+ * * Folder: a folder called "zscript" with a "main.ts" file inside.
+ */
+enum Workspace {
+    File,
+    Folder,
+}
+
 const ZSCRIPT_FILE = 'zscript.ts';
 const ZSCRIPT_JS_FILE = 'zscript.js';
+const ZSCRIPT_FOLDER = 'zscript';
+const ZSCRIPT_FOLDER_MAIN_FILE = `${ZSCRIPT_FOLDER}/main.ts`;
 const ZSCRIPT_CACHE_FILE = '.zscript_cache.js';
-
-const FIX_FILENAME = `mv ${ZSCRIPT_JS_FILE} ${ZSCRIPT_CACHE_FILE}`;
 
 const HELP_TEXT = `\
 Z-Script - version ${VERSION}
@@ -13,17 +23,18 @@ Usage: zsc [option] [args...]
 Options:
   -h, --help        Print this message and exit.
   -v, --version     Print the Z-Script's version and exit.
-  -w, --watch       Watch the current directory's ${ZSCRIPT_FILE} for changes.
+  -w, --watch       Watch the current directory's Z-Script for changes.
 `;
 
 main();
 
 function main() {
     const args = process.argv.slice(2);
+    const workspace = getZScriptWorkspace();
 
     if (args.length > 0) {
         if (args[0] === '-h' || args[0] === '--help') {
-            console.log(HELP_TEXT)
+            console.log(HELP_TEXT);
             return;
         }
 
@@ -33,23 +44,45 @@ function main() {
         }
 
         if (args[0] === '-w' || args[0] === '--watch') {
-            abortIfNoZScript();
-            watch();
+            abortIfNoZScript(workspace);
+            watch(workspace);
             return;
         }
     }
 
-    abortIfNoZScript();
-    recompileIfNeeded();
-    runZScript(args);
+    abortIfNoZScript(workspace);
+    recompileIfNeeded(workspace);
+    runZScript(workspace, args);
 }
 
-function watch() {
-    exec(`npx tsc-watch ${ZSCRIPT_FILE} --noClear --onSuccess \"${FIX_FILENAME}\"`);
+function getZScriptWorkspace(): Workspace | null {
+    if (Shell.fileExists(ZSCRIPT_FILE)) {
+        return Workspace.File;
+    }
+
+    if (Shell.isFolder(ZSCRIPT_FOLDER)) {
+        return Workspace.Folder;
+    }
+
+    return null;
 }
 
-function abortIfNoZScript() {
-    if (!Shell.fileExists(ZSCRIPT_FILE)) {
+function watch(workspace: Workspace) {
+    const fixFilenameCommand = getFilenameFixCommand(workspace);
+    exec(`npx tsc-watch ${ZSCRIPT_FILE} --noClear --onSuccess \"${fixFilenameCommand}\"`);
+}
+
+function getFilenameFixCommand(workspace: Workspace): string {
+    switch (workspace) {
+        case Workspace.File:
+            return `mv ${ZSCRIPT_JS_FILE} ${ZSCRIPT_CACHE_FILE}`;
+        case Workspace.Folder:
+            return `mv ${ZSCRIPT_FOLDER_MAIN_FILE} ${ZSCRIPT_CACHE_FILE}`;
+    }
+}
+
+function abortIfNoZScript(workspace: Workspace | null): asserts workspace is Workspace {
+    if (workspace === null) {
         const STYLE_ERROR = Format.foreground(Color.Red) + Format.bold();
         const STYLE_RESET = Format.reset();
         console.log(`${STYLE_ERROR}Error:${STYLE_RESET} no ${ZSCRIPT_FILE} file found.`);
@@ -57,23 +90,49 @@ function abortIfNoZScript() {
     }
 }
 
-function recompileIfNeeded() {
-    if (needsRecompilation()) {
-        const STYLE_COMPILING = Format.foreground(Color.Yellow);
-        const STYLE_RESET = Format.reset();
-        console.log(`${STYLE_COMPILING}Compiling Z-Script...${STYLE_RESET}`);
-        exec(`npx tsc ${ZSCRIPT_FILE} && ${FIX_FILENAME}`);
+function recompileIfNeeded(workspace: Workspace) {
+    if (needsRecompilation(workspace)) {
+        recompile(workspace);
     }
 }
 
-function needsRecompilation(): boolean {
+function needsRecompilation(workspace: Workspace): boolean {
     if (!Shell.fileExists(ZSCRIPT_CACHE_FILE)) {
         return true;
     }
 
-    return Shell.isNewerThan(ZSCRIPT_FILE, ZSCRIPT_CACHE_FILE);
+    switch (workspace) {
+        case Workspace.File:
+            return Shell.isNewerThan(ZSCRIPT_FILE, ZSCRIPT_CACHE_FILE);
+        case Workspace.Folder:
+            return Shell.isNewerThan(ZSCRIPT_FOLDER, ZSCRIPT_CACHE_FILE);
+    }
 }
 
-function runZScript(args: string[]) {
-    exec(`node ${ZSCRIPT_CACHE_FILE} ${args.join(' ')}`);
+function recompile(workspace: Workspace) {
+    const STYLE_COMPILING = Format.foreground(Color.Yellow);
+    const STYLE_RESET = Format.reset();
+    console.log(`${STYLE_COMPILING}Compiling Z-Script...${STYLE_RESET}`);
+
+    const fixFilenameCommand = getFilenameFixCommand(workspace);
+
+    switch (workspace) {
+        case Workspace.File:
+            exec(`npx tsc ${ZSCRIPT_FILE} && ${fixFilenameCommand}`);
+            break;
+        case Workspace.Folder:
+            exec(`npx tsc ${ZSCRIPT_FOLDER_MAIN_FILE} && ${fixFilenameCommand}`);
+            break;
+    }
+}
+
+function runZScript(workspace: Workspace, args: string[]) {
+    switch (workspace) {
+        case Workspace.File:
+            exec(`node ${ZSCRIPT_CACHE_FILE} ${args.join(' ')}`);
+            break;
+        case Workspace.Folder:
+            exec(`node ${ZSCRIPT_FOLDER_MAIN_FILE} ${args.join(' ')}`);
+            break;
+    }
 }

--- a/src/zsc.ts
+++ b/src/zsc.ts
@@ -57,11 +57,24 @@ function main() {
 }
 
 function getZScriptWorkspace(): Workspace | null {
-    if (Shell.fileExists(ZSCRIPT_FILE)) {
+    const fileExists = Shell.fileExists(ZSCRIPT_FILE);
+    const folderExists = Shell.fileExists(ZSCRIPT_FOLDER) && Shell.isFolder(ZSCRIPT_FOLDER);
+
+    if (fileExists && folderExists) {
+        const STYLE_ERROR = Format.foreground(Color.Red) + Format.bold();
+        const STYLE_RESET = Format.reset();
+        console.log(
+            `${STYLE_ERROR}Error:${STYLE_RESET} ambiguous Z-Script: both a file named ` +
+            `"${ZSCRIPT_FILE}" and a folder named "${ZSCRIPT_FOLDER}" exist in the current directory.`
+        );
+        process.exit(1);
+    }
+
+    if (fileExists) {
         return Workspace.File;
     }
 
-    if (Shell.fileExists(ZSCRIPT_FOLDER) && Shell.isFolder(ZSCRIPT_FOLDER)) {
+    if (folderExists) {
         return Workspace.Folder;
     }
 


### PR DESCRIPTION
This PR adds support for splitting a Z-Script into multiple files, inside a folder called "zscript". In these cases, there must be a file named "main.ts" that represents the entry point. If both a file "zscript.ts" and a folder "zscript" exist, an ambiguity error is thrown.